### PR TITLE
投稿一覧の表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
-    @item = Item.all
+    @item = Item.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
-    # @item = Item.all
+    @item = Item.all
+
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
     @item = Item.all
-
   end
 
   def new

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,4 +1,3 @@
-  <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
   <li class='list'>
     <%= link_to "#" do %>
     <div class='item-img-content'>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,27 @@
+  <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+  <li class='list'>
+    <%= link_to "#" do %>
+    <div class='item-img-content'>
+      <%= image_tag item.image, class: "item-img" %>
+
+      <%# 商品が売れていればsold outを表示しましょう %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れていればsold outを表示しましょう %>
+
+    </div>
+    <div class='item-info'>
+      <h3 class='item-name'>
+        <%= item.item_name %>
+      </h3>
+      <div class='item-price'>
+        <span><%= item.price %>円<br><%= item.shipping_charge.name %></span>
+        <div class='star-btn'>
+          <%= image_tag "star.png", class:"star-icon" %>
+          <span class='star-count'>0</span>
+        </div>
+      </div>
+    </div>
+    <% end %>
+  </li>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,37 +128,13 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+     <% if @item.present? %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+      <%= render partial: 'item', collection: @item %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+     <% else %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <%# ダミー %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +152,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+     <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Item, type: :model do
     end
     context '新規登録できないとき' do
       it 'item_nameが空では登録できない' do
-        @item.item_name = ""
+        @item.item_name = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Item name can't be blank")
       end


### PR DESCRIPTION
# What
商品一覧表示機能の追加
# why
投稿された商品をページに一覧として表示するため

投稿されたデータがないときのダミーの教示
https://gyazo.com/65e3e0811531466daf5ebb95bcf33664

データが有るときの投稿の表示
https://gyazo.com/d1a4ba3119c5555af191320e6f4694ec